### PR TITLE
Simplify configuration and group by tag titles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version      = "0.1.1"
+version      = "0.2.0"
 name         = "git-changelog"
 authors      = ["Aldrin J D'Souza <mail@aldrin.co>"]
 description  = "A tool to automate project changelog generation."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/aldrin/git-changelog.svg?branch=master)](https://travis-ci.org/aldrin/git-changelog)
+[![Build Status]](https://travis-ci.org/aldrin/git-changelog)
 
 `git-changelog` is a tool to automate repository [changelog] generation.
 
@@ -10,8 +10,8 @@ this](resources/sample.md).
 Commit messages must always be meaningful and with a little extra effort we can automate the chore
 of generating meaningful change logs for end-users. As I finish up work on a change, I like to pause
 a while, consider what the change means to the end-user and reorganize the message a bit. If you
-follow the (easy) conventions described below and tag lines appropriately, the tool will help you
-generate an *accurate* and *presentable* change log.
+follow the (easy) conventions described below and tag lines in the message appropriately, this tool
+will help you generate an *accurate* and *presentable* change log.
 
 A little time spent at the time of commit, when the context and impact of the change is fresh in
 mind, saves a lot of time at release milestones.
@@ -20,6 +20,13 @@ mind, saves a lot of time at release milestones.
 
 ```bash
 > cargo install git-changelog
+```
+
+If you use a Mac with [Homebrew], you may prefer the following:
+
+```
+> brew tap aldrin/tools
+> brew install git-changelog
 ```
 
 ## Usage
@@ -51,18 +58,20 @@ Add support for filtering responses
   the new request parameter.
 ```
 
-They're both the same but the latter tags *user visible* changes diligently. The tool picks up these
-tags, aggregates similar tags (e.g. breaking changes) together, orders them, and gives you a report
-that you can share with users.
+They're both the same but the latter tags *user visible* changes diligently. Later, the tool picks
+up these tags, aggregates similar tags (e.g. breaking changes) across commits, orders them, and
+gives you a report that you can share, as is, with users. Or, you can use the output as the starting
+draft, make editorial changes and then share it. Either way, it saves you some time.
 
-Of course, you don't need to do this for **every** commit (`git commit -m` is perfectly fine, where
-you think it is). You just need to tag the changes you want your users to know about. If configured,
-even the tags optional and you're free to tag as much or as little as you see useful.
+Of course, you don't need to tag **every** commit (`git commit -m` is perfectly fine, where you
+think it is). You just need to tag the changes you want your users to know about. The quality of the
+tool output depends on the quality of *your* input.
 
 ## Generate reports
 
-To generate report you specify a [commit range] and the tool looks for all commits in the range and
-uses the ones with the tags (ignoring others that don't) to generate a report.
+When `git-changelog` is on the path, `git changelog` works just like `git log` and takes the same
+arguments. Concretely, it takes a [commit range] and looks for all commits in that range and uses
+the tags it finds to generate a report. Simple. :)
 
 ```bash
 > git changelog -h
@@ -92,11 +101,13 @@ The default revision range picks all commits made since the *last* tag.
 *Tags*: You can specify a configuration file to define the tags and scopes you want to use for your
 project.  See the [default configuration file](resources/config.yml) for a starting example.
 
-*Template*: You can specify a [Handlerbars] template to control the rendered report format. The
+*Template*: You can specify a [Handlebars] template to control the rendered report format. The
 [default template](resources/report.handlebars) generates a Markdown document that renders well on
 Github.
 
 [normally]:https://chris.beams.io/posts/git-commit/
 [changelog]: http://keepachangelog.com/
+[Build Status]: (https://travis-ci.org/aldrin/git-changelog.svg?branch=master)
 [commit range]: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#_commit_ranges
 [Handlebars]: http://handlebarsjs.com/
+[Homebrew]: https://brew.sh/

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ this](resources/sample.md).
 ## Motivation
 
 Commit messages must always be meaningful and with a little extra effort we can automate the chore
-of generating meaningful change logs for end-users. As I finish up work on a change, I like to pause
-a while, consider what the change means to the end-user and reorganize the message a bit. If you
-follow the (easy) conventions described below and tag lines in the message appropriately, this tool
-will help you generate an *accurate* and *presentable* change log.
+of generating meaningful change logs for our users. As I finish up work on a change to a repository,
+I like to pause a while, consider what the change means to the end-user and reorganize the message a
+bit. If you follow the (easy) conventions described below and tag lines in your commit message
+appropriately, this tool will help you generate an *accurate* and *presentable* change log.
 
-A little time spent at the time of commit, when the context and impact of the change is fresh in
-mind, saves a lot of time at release milestones.
+A little time spent at commit, when the context and impact of the change is fresh in mind, saves a
+lot of time at release milestones.
 
 ## Installation
 
@@ -24,7 +24,7 @@ mind, saves a lot of time at release milestones.
 
 If you use a Mac with [Homebrew], you may prefer the following:
 
-```
+```bash
 > brew tap aldrin/tools
 > brew install git-changelog
 ```
@@ -32,7 +32,7 @@ If you use a Mac with [Homebrew], you may prefer the following:
 ## Usage
 
 Just write your commits as you [normally] do. When it looks like a particular commit includes a
-change that the "user" may be interested in, tag it appropriately.
+change that the "user" may be interested in, tag its lines appropriately.
 
 Concretely, instead of writing this:
 
@@ -58,10 +58,11 @@ Add support for filtering responses
   the new request parameter.
 ```
 
-They're both the same but the latter tags *user visible* changes diligently. Later, the tool picks
-up these tags, aggregates similar tags (e.g. breaking changes) across commits, orders them, and
-gives you a report that you can share, as is, with users. Or, you can use the output as the starting
-draft, make editorial changes and then share it. Either way, it saves you some time.
+The two commit messages are almost the same but the latter tags *user visible* changes a bit more
+diligently. Eventually, this diligence helps the tool to identify lines, aggregate similar things
+(e.g. breaking changes) across commits, order them, and give you a report that you can share, as is,
+with users. Or, you can use the output as the starting draft, make editorial changes and then share
+it with users. Either way, it saves you some time.
 
 Of course, you don't need to tag **every** commit (`git commit -m` is perfectly fine, where you
 think it is). You just need to tag the changes you want your users to know about. The quality of the
@@ -69,13 +70,12 @@ tool output depends on the quality of *your* input.
 
 ## Generate reports
 
-When `git-changelog` is on the path, `git changelog` works just like `git log` and takes the same
+When `git-changelog` is on the path, `git changelog` works just like `git log` and takes similar
 arguments. Concretely, it takes a [commit range] and looks for all commits in that range and uses
-the tags it finds to generate a report. Simple. :)
+the tags it finds in their messages to generate a report. Simple. :)
 
 ```bash
-> git changelog -h
-git-changelog (v0.1.0)
+git-changelog (v0.2.0)
 Aldrin J D'Souza <mail@aldrin.co>
 A tool to automate project changelog generation.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Github.
 
 [normally]:https://chris.beams.io/posts/git-commit/
 [changelog]: http://keepachangelog.com/
-[Build Status]: (https://travis-ci.org/aldrin/git-changelog.svg?branch=master)
+[Build Status]: https://travis-ci.org/aldrin/git-changelog.svg?branch=master
 [commit range]: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#_commit_ranges
 [Handlebars]: http://handlebarsjs.com/
 [Homebrew]: https://brew.sh/

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -5,56 +5,37 @@
 # overridden using the `-c` or `--config` command line parameter.
 
 ## Project Conventions
-# Change categorization
+
+# The category tags and their titles.
+
+# Changes are grouped by title so you can put items tagged
+# with different keywords (e.g. break and braek) into the
+# same report section by giving them the same title.
+
+# Items tagged with keywords not on the list (e.g. chore)
+# will be skipped from the final report.
+
+# The item with an empty string keyword applies to lines
+# that have no explicit tags.
+
+# The order of tag definitions in the configuration controls
+# the order in which the tags
 categories:
+  - {keyword: "security", title: "Security Updates"}
+  - {keyword: "break", title: "Breaking Changes"}
+  - {keyword: "feature", title: "Features"}
+  - {keyword: "fix", title: "Fixes"}
+  - {keyword: "", title: "Notes"}
+  - {keyword: "add", title: "Additions"}
+  - {keyword: "remove", title: "Removals"}
+  - {keyword: "deprecate", title: "Deprecations"}
 
-  # The tags used to categorize changes in commit messages.
-  # The order here, determines the order these appear in the final report.
-  # If a tag is not on this list, it won't show up in the final report.
-  tags:
-    - break
-    - security
-    - feature
-    - add
-    - remove
-    - fix
-    - note
-    - deprecate
+# The scope tags and their titles.
 
-  # The category for all untagged changes.
-  default: note
-
-  # The "pretty names" for the tags as they appear in the final report.
-  titles:
-    fix: Fixes
-    note: Notes
-    add: Additions
-    remove: Removals
-    feature: Features
-    deprecate: Deprecations
-    break: Breaking Changes
-    security: Security Updates
-
+# The scope configuration follows the same conventions as
+# category. Remember that if you don't use scopes all items
+# are tagged under the default scope (i.e. keyword="").
 scopes:
-
-  # The tags used to scope changes in commit messages
-  # The order here, determines the order these appear in the final report.
-  # If a tag is not on this list, it won't show up in the final report.  
-  tags:
-    - default
-    - api
-    - doc
-
-  # The scope for all untagged changes
-  default: default
-
-  # The "pretty names" for the tags as they appear in the final report.
-  titles:
-    api: API
-    default: ""
-    doc: Documentation
-
-## Report Configuration
-report:
-  title: "CHANGELOG"
-  date_format: "%Y-%m-%d"
+  - {keyword: "", title: ""}
+  - {keyword: "api", title: "API"}
+  - {keyword: "doc", title: "Documentation"}

--- a/resources/report.handlebars
+++ b/resources/report.handlebars
@@ -2,11 +2,6 @@
 {{!-- Licensed under the MIT License <https://opensource.org/licenses/MIT> --}}
 
 {{!-- The default Markdown report format --}}
-{{#if title }}
-### {{ title }} ({{ date }})
-
-{{/if ~}}
-
 {{!-- Headlines  --}}
 #### Summary
 {{#each commits }}
@@ -21,9 +16,9 @@
 {{~#each categories }}
 {{#if title}}##### {{{ title }}}{{/if}}
 {{#each changes }}
-- {{{ opening ~}}}
+-{{{ opening ~}}}
   {{#each rest }}
-    {{{ . ~}}}
+  {{{ . ~}}}
   {{/each}}
 {{/each}}
 {{/each}}

--- a/resources/sample-commit.message
+++ b/resources/sample-commit.message
@@ -7,18 +7,18 @@ messages. The only additional (and optional) conventions this tool
 introduces are the tagging prefixes described here.
 
 - feature: *Categorized Changes:* Lines that begin with a `- <tag>:` can
-  be used to categorize changes. Everything that follows the prefix is
-  tagged with the chosen category. For example, this text describes the
-  tool feature that categorizes changes. Among others, `feature` is an
-  out-of-the-box tag defined in the [configuration](config.yml). You can
-  define tags that make sense for your project.
+be used to categorize changes. Everything that follows the prefix is
+tagged with the chosen category. For example, this text describes the
+tool feature that categorizes changes. Among others, `feature` is an
+out-of-the-box tag defined in the [configuration](config.yml). You can
+define tags that make sense for your project.
 
 - feature: *Scoped Changes:* For larger projects, the tool supports
 another level of organization using *scopes*. For example, projects can
 organize API changes under a `API` scope. To specify a scope, use the
-*`- tag(scope):`* prefix. When you don't specify a scope the item goes
-into the `default` scope. As with tags, you can define scopes that make
-sense for your project like `docs`, `benchmark`, etc. You can also
+*`- <tag>(<scope>):`* prefix. When you don't specify a scope the item
+goes into the `default` scope. As with tags, you can define scopes that
+make sense for your project like `docs`, `benchmark`, etc. You can also
 ignore them entirely and just use simple category tags.
 
 - break(API): This item is an example of a scoped *and* categorized

--- a/resources/sample.md
+++ b/resources/sample.md
@@ -1,5 +1,3 @@
-### CHANGELOG (2017-11-25)
-
 #### Summary
 
 - [#4] Demonstrate tagging conventions for commit messages
@@ -7,33 +5,32 @@
 
 ##### Features
 
--  *Categorized Changes:* Lines that begin with a `- <tag>:` can
-      be used to categorize changes. Everything that follows the prefix is
-      tagged with the chosen category. For example, this text describes the
-      tool feature that categorizes changes. Among others, `feature` is an
-      out-of-the-box tag defined in the [configuration](config.yml). You can
-      define tags that make sense for your project.
-    
+- *Categorized Changes:* Lines that begin with a `- <tag>:` can
+  be used to categorize changes. Everything that follows the prefix is
+  tagged with the chosen category. For example, this text describes the
+  tool feature that categorizes changes. Among others, `feature` is an
+  out-of-the-box tag defined in the [configuration](config.yml). You can
+  define tags that make sense for your project.
+  
 
--  *Scoped Changes:* For larger projects, the tool supports
-    another level of organization using *scopes*. For example, projects can
-    organize API changes under a `API` scope. To specify a scope, use the
-    *`- tag(scope):`* prefix. When you don't specify a scope the item goes
-    into the `default` scope. As with tags, you can define scopes that make
-    sense for your project like `docs`, `benchmark`, etc. You can also
-    ignore them entirely and just use simple category tags.
-    
+- *Scoped Changes:* For larger projects, the tool supports
+  another level of organization using *scopes*. For example, projects can
+  organize API changes under a `API` scope. To specify a scope, use the
+  *`- <tag>(<scope>):`* prefix. When you don't specify a scope the item
+  goes into the `default` scope. As with tags, you can define scopes that
+  make sense for your project like `docs`, `benchmark`, etc. You can also
+  ignore them entirely and just use simple category tags.
+  
 
 
 ##### Notes
 
-- 
-    This commit message is long to demonstrate the tool features. *Real*
-    commits should follow the standard
-    [guidance](https://chris.beams.io/posts/git-commit/) on writing commit
-    messages. The only additional (and optional) conventions this tool
-    introduces are the tagging prefixes described here.
-    
+- This commit message is long to demonstrate the tool features. *Real*
+  commits should follow the standard
+  [guidance](https://chris.beams.io/posts/git-commit/) on writing commit
+  messages. The only additional (and optional) conventions this tool
+  introduces are the tagging prefixes described here.
+  
 
 
 
@@ -41,29 +38,29 @@
 #### API
 ##### Breaking Changes
 
--  This item is an example of a scoped *and* categorized
-    change. The text here and all that follows will show up under a
-    "Breaking Changes" section in the "API" scope of the project. You can
-    use this to describe the change as you wish. For example, for a breaking
-    change, you may want to itemize things like:
-    
-     - **Why** the breaking change was necessary.
-     - **What** the users should do about it.
-    
-    You can even put code snippets like this:
-    
-    ```rust
-    /// A single line in the change message
-    #[derive(Default, Serialize)]
-    pub struct Line {
-        /// The scope
-        pub scope: Option<String>,
-        /// The category
-        pub category: Option<String>,
-        /// The text
-        pub text: Option<String>,
-    }
-    ```
-    
-    All text that follows a tagged line is implicitly categorized under the
-    currently active tags.
+- This item is an example of a scoped *and* categorized
+  change. The text here and all that follows will show up under a
+  "Breaking Changes" section in the "API" scope of the project. You can
+  use this to describe the change as you wish. For example, for a breaking
+  change, you may want to itemize things like:
+  
+   - **Why** the breaking change was necessary.
+   - **What** the users should do about it.
+  
+  You can even put code snippets like this:
+  
+  ```rust
+  /// A single line in the change message
+  #[derive(Default, Serialize)]
+  pub struct Line {
+      /// The scope
+      pub scope: Option<String>,
+      /// The category
+      pub category: Option<String>,
+      /// The text
+      pub text: Option<String>,
+  }
+  ```
+  
+  All text that follows a tagged line is implicitly categorized under the
+  currently active tags.

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -75,7 +75,7 @@ pub fn parse_number(line: &str) -> Option<u32> {
     }
 }
 
-/// Parse an indvidiual line item
+/// Parse an individual message line
 pub fn parse_line(line: &str) -> Line {
     match tagged_change(line) {
         IResult::Done(_, l) => l,
@@ -83,7 +83,7 @@ pub fn parse_line(line: &str) -> Line {
     }
 }
 
-/// A change line is one of the known types
+/// A change message line is one of the following types
 named!(tagged_change<&str, Line>,
        alt!(
            category_scope_change
@@ -141,7 +141,7 @@ named!(category_change<&str, Line>,
 
 /// A line that has just a simple change (no tags).
 named!(just_change<&str, Line>,
-       do_parse!(opt!(ws!(tag!("-"))) >>
+       do_parse!(opt!(tag!("-")) >>
                  text: whatever >>
                  (Line{
                      scope: None,
@@ -156,4 +156,3 @@ named!(whatever<&str, String>,
 /// Consume an acceptable tag name and return a String
 named!(tagname<&str, String>,
        map!(ws!(take_while1_s!(|c| is_alphanumeric(c as u8))), str::to_lowercase));
-

--- a/src/git.rs
+++ b/src/git.rs
@@ -11,7 +11,7 @@ pub fn in_git_repository() -> Result<Output, Error> {
     git(&["rev-parse", "--is-inside-work-tree"])
 }
 
-/// Get the last tag, if no tags exist, go one commit back
+/// Get the last tag
 pub fn last_tag() -> Result<Option<String>, Error> {
     last_tags(1).map(|mut v| v.pop())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,4 +26,5 @@ pub mod tool;
 pub mod commit;
 pub mod config;
 pub mod report;
+pub mod output;
 mod tests;

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 Aldrin J D'Souza.
+// Licensed under the MIT License <https://opensource.org/licenses/MIT>
+
+// Output concerns
+
+use report::Report;
+use config::Configuration;
+use handlebars::Handlebars;
+
+/// Render the given report with the given configuration
+pub fn render(config: &Configuration, report: &Report) {
+    let out = Handlebars::new()
+        .template_render(&config.template, report)
+        .unwrap()
+        .trim()
+        .to_string();
+
+    println!("{}", out);
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -2,20 +2,15 @@
 // Licensed under the MIT License <https://opensource.org/licenses/MIT>
 
 /// Presentation and Reporting
-use chrono::Local;
+use config;
 use commit::Commit;
 use config::Configuration;
-use handlebars::Handlebars;
 use std::collections::HashMap;
 use serde_json::to_string_pretty;
 
 /// The complete report
 #[derive(Serialize)]
 pub struct Report<'a> {
-    /// The time of report generation
-    pub date: String,
-    /// The report title
-    pub title: String,
     /// Scoped changes in the report
     pub scopes: Vec<Scope>,
     /// All interesting commits
@@ -49,25 +44,6 @@ pub struct Text {
     pub rest: Vec<String>,
 }
 
-/// Generate a new report for the commits with the given configuration
-pub fn generate<'a>(commits: &'a [Commit], config: &'a Configuration) -> Report<'a> {
-    Report {
-        commits,
-        scopes: organize(config, commits),
-        title: config.report.title.clone(),
-        date: Local::now().format(&config.report.date_format).to_string(),
-    }
-}
-
-/// Render the given report with the given configuration
-pub fn render(report: &Report, config: &Configuration) -> String {
-    Handlebars::new()
-        .template_render(&config.report.template, report)
-        .unwrap()
-        .trim()
-        .to_string()
-}
-
 /// A temporary report structure with look-ups on scope and category keys
 type RawReport = HashMap<String, HashMap<String, Vec<Text>>>;
 
@@ -82,43 +58,39 @@ struct State {
     category: Option<String>,
 }
 
-/// Record the current state into the raw report
-fn record(raw: &mut RawReport, config: &Configuration, mut state: State) {
-    // Validate the category with the configuration
-    let category = config.categories.validate(state.category);
+/// Generate a new report for the commits with the given configuration
+pub fn generate<'a>(config: &'a Configuration, commits: &'a [Commit]) -> Report<'a> {
 
-    // Validate the scope with the configuration
-    let scope = config.scopes.validate(state.scope);
+    // First pass - categorize
+    let raw_report = first_pass(config, commits);
 
-    // If the scope and category are known and we have some text to record
-    if category.is_some() && scope.is_some() && !state.text.is_empty() {
-        // Split the opening line and the remainder
-        let opening = state.text.remove(0);
-        let rest = state.text;
+    // Second pass - aggregate
+    let scopes = second_pass(config, &raw_report);
 
-        // Record it in the raw report
-        raw.entry(scope.unwrap())
-            .or_insert_with(HashMap::new)
-            .entry(category.unwrap())
-            .or_insert_with(Vec::new)
-            .push(Text { opening, rest });
-    }
+    // Done
+    Report { commits, scopes }
 }
 
-/// Group the commits into scopes
-fn organize(config: &Configuration, commits: &[Commit]) -> Vec<Scope> {
-    let report = &mut RawReport::new();
+/// The first pass - walks through commits and gathers scopes and categories.
+fn first_pass(config: &Configuration, commits: &[Commit]) -> RawReport {
+
+    // A running raw report
+    let mut raw_report = RawReport::new();
 
     // Take each commit
     for commit in commits {
+
+        // Initialize a fresh current
         let mut current = State::default();
 
         // Take each line in the message
         for line in &commit.lines {
+
             // If this line opens a new category
             if line.category.is_some() {
+
                 // Close out the current item
-                record(report, config, current.clone());
+                record(&mut raw_report, config, current.clone());
 
                 // Start a new context
                 current.text = Vec::new();
@@ -131,35 +103,39 @@ fn organize(config: &Configuration, commits: &[Commit]) -> Vec<Scope> {
         }
 
         // Close the last open item
-        record(report, config, current);
+        record(&mut raw_report, config, current);
     }
 
-    // Log the report for debugging
-    info!("{}", to_string_pretty(&report).unwrap());
+    // Log the raw_report for debugging
+    info!("RAW_REPORT: {}", to_string_pretty(&raw_report).unwrap());
 
-    // Finalize
-    finish(report, config)
+    raw_report
 }
 
-/// Create the final report from the given raw report and configuration
-fn finish(report: &RawReport, config: &Configuration) -> Vec<Scope> {
+/// The second pass takes the raw report and orders things as we want to show them
+fn second_pass(config: &Configuration, report: &RawReport) -> Vec<Scope> {
+
     // The report of all scopes
     let mut scopes = Vec::new();
 
     // Go through each configured scope
-    for scope in &config.scopes.tags {
+    for scope in &config.scopes {
+
         // If we have changes for the scope in the report
-        if let Some(categorized) = report.get(scope) {
+        if let Some(categorized) = report.get(&scope.title) {
+
             // The scoped categorized changes
             let mut categories = Vec::new();
 
             // Go through all configured scopes
-            for category in &config.categories.tags {
+            for category in &config.categories {
+
                 // If there are changes of this category
-                if let Some(changes) = categorized.get(category) {
+                if let Some(changes) = categorized.get(&category.title) {
+
                     // Add them to the running list
                     categories.push(Category {
-                        title: config.categories.get_title(category),
+                        title: category.title.clone(),
                         changes: changes.clone(),
                     });
                 }
@@ -167,7 +143,7 @@ fn finish(report: &RawReport, config: &Configuration) -> Vec<Scope> {
 
             // Record them in the scopes list
             scopes.push(Scope {
-                title: config.scopes.get_title(scope),
+                title: scope.title.clone(),
                 categories,
             });
         }
@@ -175,4 +151,45 @@ fn finish(report: &RawReport, config: &Configuration) -> Vec<Scope> {
 
     // Done
     scopes
+}
+
+/// Record the current state into the raw report
+fn record(raw: &mut RawReport, config: &Configuration, mut state: State) {
+
+    // Validate the scope with the configuration
+    let scope = config::report_title(&config.scopes, &state.scope);
+
+    // Validate the category with the configuration
+    let category = config::report_title(&config.categories, &state.category);
+
+    // If the scope and category are known and we have some text to record
+    if category.is_some() && scope.is_some() && !state.text.is_empty() {
+
+        // Split the opening line and the remainder
+        let mut opening = state.text.remove(0);
+
+        // If the opening line is empty,
+        while opening.trim().is_empty() {
+
+            // take the next one
+            opening = state.text.remove(0)
+        }
+
+        // If the opening line has no buffer space,
+        if !opening.starts_with(' ') {
+
+            // add it
+            opening.insert(0, ' ');
+        }
+
+        // Take the rest
+        let rest = state.text;
+
+        // Record it in the raw report
+        raw.entry(scope.unwrap())
+            .or_insert_with(HashMap::new)
+            .entry(category.unwrap())
+            .or_insert_with(Vec::new)
+            .push(Text { opening, rest });
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -53,7 +53,7 @@ fn commit_parse_line() {
     let line = parse_line("- foo bar");
     assert_eq!(None, line.scope);
     assert_eq!(None, line.category);
-    assert_eq!(Some(String::from("foo bar")), line.text);
+    assert_eq!(Some(String::from(" foo bar")), line.text);
 
     let line = parse_line("foo bar");
     assert_eq!(None, line.scope);
@@ -103,12 +103,11 @@ fn prepare_report() {
     use super::*;
     let commits = vec![fake_commit()];
     let config = config::from(None).unwrap();
-    let report = report::generate(&commits, &config);
+    let report = report::generate(&config, &commits);
     println!("{}", serde_json::to_string_pretty(&report).unwrap());
-    println!("{}", report::render(&report, &config));
+    output::render(&config, &report);
     assert_eq!(report.commits.len(), 1);
     assert_eq!(report.scopes.len(), 2);
-    assert!(!report.title.is_empty());
     assert_eq!(report.scopes[0].categories[0].title, "Features");
     assert_eq!(report.scopes[0].categories[1].title, "Notes");
     assert_eq!(report.scopes[1].categories[0].title, "Breaking Changes");


### PR DESCRIPTION
- Simplify configuration by omitting tags, defaults, etc. All we
  need now are simple keyword->title mapping and keywords without
  titles are skipped from the report. The aggregation is now done
  on title (instead of tag keyword) which allows us to group
  multiple tags into one report section. For example, with tags
  `break => Breaking Change` and `braek => Breaking Change` we
  can accommodate simple typos.

- break: Configuration format has changed and old configuration
  files will need some tweaks.