### PR TITLE
Improve configuration file lookup and support post-processors

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -1,0 +1,13 @@
+# Copyright 2017 Aldrin J D'Souza.
+# Licensed under the MIT License <https://opensource.org/licenses/MIT>
+
+# The changelog configuration file for this project
+categories:
+  - {keyword: "", title: "Features"}
+  - {keyword: "feature", title: "Features"}
+  - {keyword: "break", title: "Breaking Changes"}
+
+post_processors:
+  -
+    lookup: "#(?P<pr>\\d+)"
+    replace: "[#$pr](https://github.com/aldrin/git-changelog/pull/$pr)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 
 before_deploy:
   - cargo build --release
-  - tar cfz target/release/git-changelog-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz target/release/git-changelog 
+  - tar cfz target/release/git-changelog-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz -C target/release git-changelog 
 
 os:
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: rust
 
 rust:
   - stable
-  - nightly
 
 cache: cargo
 
@@ -11,13 +10,11 @@ script:
 
 before_deploy:
   - cargo build --release
+  - tar cfz target/release/git-changelog-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz target/release/git-changelog 
 
 os:
+  - osx
   - linux
-
-matrix:
-  allow_failures:
-    - rust: nightly
 
 deploy:
 
@@ -26,7 +23,7 @@ deploy:
   api_key:
     secure: ju4NVDw2Pdi6sOyB8CegIJOwsnZIdiRwGUmxMpna2jWuoiDT9tZyhN16Kht0yjTrKc2xwb/35xdEGqOAXyXrnU/SIF01WpYkjS6IR7Lgswpq6PRQiT0PjdMyotwdc/T8Yjktp29KyEJ4QjsvK37LV/pAq6YEu8O1haap0SuvMw0pJgrRyV32m8SpXCBDfLD4f0OJZUpY6CgfiZuJrV8UIf4uPnKWw2AgkYfLcFBPC8B/pUxfjuOcHuoojxDRB1AaZ0gMnkHSKRmtlJXdFscqp424bnoPczWyNQ4FTdTIQ6rVLUrcmGP83jp8kNW6taDsuuWU9QWysgehIXOY4eDrUNGDFwcBntjvcazYy9r82W67NYcqeUcYtYj1wu9XCWY2gS0h3qL0xFIZ3VJOUFb6a/85UOyji6dpLl4iFmm+ia4g3RVbtwO7Tgv6Ir9PCEHfxJ6lNpzgBV0SCkpV6od7J29xliYJhMZHEfYMt1W3PG4SEb/R8CQKkKt2EoPFNCP05mqECg+mUh02+x+Rg0yZ1SkRpIxQYf0EIibqN3Ik4SRgYLYXMRU3wRxLZlMiwCgBzINY2JcY3H6X3XAO67dHBXjYB2K5oy0KzywNjiXQPPCeiNiAd3tGiYksI6jde1+4zAWeCzcomRHvr2gH2aCHjjZSVeXffvhzbqXhUoS0cTo=
 
-  file: target/release/git-changelog
+  file: target/release/git-changelog-$TRAVIS_TAG-$TRAVIS_OS_NAME.tar.gz
 
   skip_cleanup: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,37 @@
 language: rust
+
 rust:
   - stable
   - nightly
+
 cache: cargo
+
+script:
+  - cargo test -- --nocapture
+
+before_deploy:
+  - cargo build --release
+
 os:
   - linux
+
 matrix:
   allow_failures:
     - rust: nightly
+
+deploy:
+
+  provider: releases
+
+  api_key:
+    secure: ju4NVDw2Pdi6sOyB8CegIJOwsnZIdiRwGUmxMpna2jWuoiDT9tZyhN16Kht0yjTrKc2xwb/35xdEGqOAXyXrnU/SIF01WpYkjS6IR7Lgswpq6PRQiT0PjdMyotwdc/T8Yjktp29KyEJ4QjsvK37LV/pAq6YEu8O1haap0SuvMw0pJgrRyV32m8SpXCBDfLD4f0OJZUpY6CgfiZuJrV8UIf4uPnKWw2AgkYfLcFBPC8B/pUxfjuOcHuoojxDRB1AaZ0gMnkHSKRmtlJXdFscqp424bnoPczWyNQ4FTdTIQ6rVLUrcmGP83jp8kNW6taDsuuWU9QWysgehIXOY4eDrUNGDFwcBntjvcazYy9r82W67NYcqeUcYtYj1wu9XCWY2gS0h3qL0xFIZ3VJOUFb6a/85UOyji6dpLl4iFmm+ia4g3RVbtwO7Tgv6Ir9PCEHfxJ6lNpzgBV0SCkpV6od7J29xliYJhMZHEfYMt1W3PG4SEb/R8CQKkKt2EoPFNCP05mqECg+mUh02+x+Rg0yZ1SkRpIxQYf0EIibqN3Ik4SRgYLYXMRU3wRxLZlMiwCgBzINY2JcY3H6X3XAO67dHBXjYB2K5oy0KzywNjiXQPPCeiNiAd3tGiYksI6jde1+4zAWeCzcomRHvr2gH2aCHjjZSVeXffvhzbqXhUoS0cTo=
+
+  file: target/release/git-changelog
+
+  skip_cleanup: true
+
+  on:
+    tags: true
+    overwrite: true
+    repo: aldrin/git-changelog
+    condition: $TRAVIS_RUST_VERSION = stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ handlebars   = "0.29"
 env_logger   = "0.3"
 serde_yaml   = "0.7"
 serde_derive = "1.0"
+exitcode     = "1.1"
 
 [lib]
 name         = "changelog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ readme       = "README.md"
 log          = "0.3"
 nom          = "3.2"
 clap         = "2.26"
+regex        = "0.2"
 serde        = "1.0"
 chrono       = "0.4"
 handlebars   = "0.29"
 env_logger   = "0.3"
 serde_yaml   = "0.7"
-serde_json   = "1.0"
 serde_derive = "1.0"
 
 [lib]
@@ -28,4 +28,4 @@ name         = "git-changelog"
 doc          = false
 
 [badges]
-travis-ci    = {repository= "aldrin/git-changelog" }
+travis-ci    = {repository = "aldrin/git-changelog" }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ lot of time at release milestones.
 If you use a Mac with [Homebrew], you may prefer the following:
 
 ```bash
-> brew tap aldrin/tools
+> brew tap aldrin/tap
 > brew install git-changelog
 ```
 
@@ -74,7 +74,8 @@ When `git-changelog` is on the path, `git changelog` works just like `git log` a
 arguments. Concretely, it takes a [commit range] and looks for all commits in that range and uses
 the tags it finds in their messages to generate a report. Simple. :)
 
-```bash
+```
+> git changelog -h
 git-changelog (v0.2.0)
 Aldrin J D'Souza <mail@aldrin.co>
 A tool to automate project changelog generation.

--- a/resources/report.handlebars
+++ b/resources/report.handlebars
@@ -5,7 +5,7 @@
 {{!-- Headlines  --}}
 #### Summary
 {{#each commits }}
-- {{#if number }}[#{{ number }}]{{/if}} {{{ summary ~}}}
+- {{{ summary }}} {{#if number }}(#{{ number }}){{/if ~}} 
 
 {{/each ~}}
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -11,14 +11,19 @@ use nom::{is_alphanumeric, IResult};
 pub struct Commit {
     /// The change SHA
     pub sha: String,
+
     /// The change author
     pub author: String,
+
     /// The change timestamp
     pub time: String,
+
     /// The change summary
     pub summary: String,
+
     /// The change number
     pub number: Option<u32>,
+
     /// The message lines
     pub lines: Vec<Line>,
 }
@@ -28,60 +33,111 @@ pub struct Commit {
 pub struct Line {
     /// The scope
     pub scope: Option<String>,
+
     /// The category
     pub category: Option<String>,
+
     /// The text
     pub text: Option<String>,
 }
 
 /// Parse the commit message to a Commit object
 pub fn parse(lines: &[String], dt_format: &str) -> Commit {
+
+    // Parsed commit
     Commit {
+        // First line is the SHA
         sha: lines[0].clone(),
+
+        // Second line is the author
         author: lines[1].clone(),
+
+        // An optional change number (e.g. PR, issue number in Github)
         number: parse_number(&lines[3]),
+
+        // The change message summary
         summary: parse_subject(&lines[3]),
+
+        // Parse the timestamp
         time: parse_time(&lines[2], dt_format),
+
+        // Parse the rest of the message lines
         lines: lines[4..].iter().map(|s| parse_line(s)).collect(),
     }
 }
 
 /// Parse the commit timestamp to local time
 pub fn parse_time(line: &str, format: &str) -> String {
+
+    // Parse the git timestamp string
     DateTime::parse_from_rfc2822(line)
+
+        // Convert to local time zone
         .map(|t| t.with_timezone(&Local))
+
+        // If that fails, assume "now"
         .unwrap_or_else(|_| Local::now())
+
+        // Render with the given format 
         .format(format)
+
+        // Done
         .to_string()
 }
 
 /// Parse the commit subject removing the numbers tags.
 pub fn parse_subject(line: &str) -> String {
+
+    // Find the first number opener on the commit subject
     let first_open = line.find("(#").unwrap_or_else(|| line.len());
+
+    // Everything up to the first number opener is the subject
     String::from(line.get(0..first_open).unwrap_or_else(|| line).trim())
 }
 
 /// Parse the commit number
 pub fn parse_number(line: &str) -> Option<u32> {
+
+    // The commit number is the last number on the subject
     let last_open = line.rfind("(#");
+
+    // The last number opener
     let last_close = line.rfind(')');
+
+    // If no number found on subject line
     if last_open.is_none() || last_close.is_none() {
+
+        // The commit has no number
         None
     } else {
+
+        // Extract the bounds of the last number
         let end = last_close.unwrap();
         let start = last_open.unwrap() + "(#".len();
+
+        // Parse it to a number
         let num = line.get(start..end).map(|s| s.parse().ok());
+
+        // If valid, we have a number
         num.unwrap_or(None)
     }
 }
 
 /// Parse an individual message line
 pub fn parse_line(line: &str) -> Line {
+
+    // Parse the tags in the line
     match tagged_change(line) {
+
+        // If parser succeeded, we have our line
         IResult::Done(_, l) => l,
+
+        // If parser fails, draw a blank
         _ => Line::default(),
     }
 }
+
+// -- nom parsers follow -- //
 
 /// A change message line is one of the following types
 named!(tagged_change<&str, Line>,

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Local};
 use nom::{is_alphanumeric, IResult};
 
 /// A single commit
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Commit {
     /// The change SHA
     pub sha: String,
@@ -24,7 +24,7 @@ pub struct Commit {
 }
 
 /// A single line in the change message
-#[derive(Default, Serialize)]
+#[derive(Default, Serialize, Debug)]
 pub struct Line {
     /// The scope
     pub scope: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use handlebars::Handlebars;
 use std::io::{Error, ErrorKind, Read, BufReader};
 
 /// The default configuration file name
-pub const FILE: &'static str = ".changelog.yml";
+pub const FILE: &str = ".changelog.yml";
 
 /// A tag definition
 #[serde(default)]
@@ -17,6 +17,7 @@ pub const FILE: &'static str = ".changelog.yml";
 pub struct Tag {
     /// The identifying keyword
     pub keyword: String,
+
     /// The report heading
     pub title: String,
 }
@@ -27,6 +28,7 @@ pub struct Tag {
 pub struct PostProcessor {
     /// The lookup pattern
     pub lookup: String,
+
     /// The replace pattern
     pub replace: String,
 }
@@ -37,23 +39,28 @@ pub struct PostProcessor {
 pub struct Configuration {
     /// The change category configuration
     pub categories: Vec<Tag>,
+
     /// The change scope configuration
     pub scopes: Vec<Tag>,
+
     /// The report title
     pub title: String,
+
     /// The report template file
     pub template: String,
+
     /// The date format
     pub date_format: String,
+
     /// The line post-processors
     pub post_processors: Vec<PostProcessor>,
 }
 
 /// Initialize configuration from the given file or use the default.
-pub fn from(filename: Option<String>) -> Result<Configuration, Error> {
+pub fn from(filename: &Option<String>) -> Result<Configuration, Error> {
 
     // Take the given filename
-    let mut config: Configuration = match filename {
+    let mut config: Configuration = match *filename {
 
         // If none is given, initialize from the embedded default
         None => {
@@ -103,7 +110,7 @@ pub fn from(filename: Option<String>) -> Result<Configuration, Error> {
     if config.date_format.is_empty() {
 
         // Use a sensible default
-        config.date_format = "%Y-%m-%d".to_string()
+        config.date_format = "%Y-%m-%d %H:%M".to_string()
     }
 
     // If no scopes are specified
@@ -129,12 +136,22 @@ pub fn from(filename: Option<String>) -> Result<Configuration, Error> {
 
 /// Get the report title for a given tag
 pub fn report_title(tags: &[Tag], given: &Option<String>) -> Option<String> {
-    let given = given.clone().unwrap_or_default();
+
+    // Get the tag keyword (or blank, if none exists)
+    let keyword = given.clone().unwrap_or_default();
+
+    // Look for all known tags
     for tag in tags {
-        if tag.keyword == given {
+
+        // If the keywords match
+        if tag.keyword == keyword {
+
+            // Return the title
             return Some(tag.title.clone());
         }
     }
+
+    // Nothing found
     None
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,13 @@
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_yaml;
-extern crate serde_json;
 #[macro_use]
 extern crate log;
 extern crate chrono;
 #[macro_use]
 extern crate nom;
 extern crate handlebars;
+extern crate regex;
 
 pub mod git;
 pub mod tool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ extern crate chrono;
 extern crate nom;
 extern crate handlebars;
 extern crate regex;
+extern crate exitcode;
 
 pub mod git;
 pub mod tool;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
     let filename = changelog::config::find_file(cli.value_of("config"));
 
     // Initialize the configuration and run the tool
-    let result = match changelog::config::from(filename) {
+    let result = match changelog::config::from(&filename) {
         Ok(c) => changelog::tool::run(&c, cli.values_of_lossy("revision-range")),
         _ => -1,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ use env_logger::LogBuilder;
 use log::{LogRecord, LogLevelFilter};
 
 fn main() {
+
+    // Initialize the CLI
     let cli = App::new(env!("CARGO_PKG_NAME"))
         .author(env!("CARGO_PKG_AUTHORS"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
@@ -39,13 +41,19 @@ fn main() {
         )
         .get_matches();
 
+    // Initialize log verbosity
     init_logging(cli.occurrences_of("debug"));
 
-    let result = match changelog::config::from(cli.value_of("config")) {
+    // Identify the configuration file we're going to use
+    let filename = changelog::config::find_file(cli.value_of("config"));
+
+    // Initialize the configuration and run the tool
+    let result = match changelog::config::from(filename) {
         Ok(c) => changelog::tool::run(&c, cli.values_of_lossy("revision-range")),
         _ => -1,
     };
 
+    // Done
     exit(result);
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -21,7 +21,7 @@ pub fn render(config: &Configuration, report: &Report) {
     // If we have line post processors,
     if !config.post_processors.is_empty() {
         // Post-process the output lines
-        out = postprocess(&config, out);
+        out = postprocess(config, &out);
     }
 
     // Print it out
@@ -29,7 +29,7 @@ pub fn render(config: &Configuration, report: &Report) {
 }
 
 /// Postprocess the output before printing it out
-pub fn postprocess(config: &Configuration, output: String) -> String {
+pub fn postprocess(config: &Configuration, output: &str) -> String {
 
     // Compile the post processor regular expressions
     let mut processors = Vec::new();

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,17 +3,73 @@
 
 // Output concerns
 
+use regex::Regex;
 use report::Report;
 use config::Configuration;
 use handlebars::Handlebars;
 
 /// Render the given report with the given configuration
 pub fn render(config: &Configuration, report: &Report) {
-    let out = Handlebars::new()
+
+    // Render the report using Handlebars
+    let mut out = Handlebars::new()
         .template_render(&config.template, report)
         .unwrap()
         .trim()
         .to_string();
 
+    // If we have line post processors,
+    if !config.post_processors.is_empty() {
+        // Post-process the output lines
+        out = postprocess(&config, out);
+    }
+
+    // Print it out
     println!("{}", out);
+}
+
+/// Postprocess the output before printing it out
+pub fn postprocess(config: &Configuration, output: String) -> String {
+
+    // Compile the post processor regular expressions
+    let mut processors = Vec::new();
+    for processor in &config.post_processors {
+
+        // Processor the lookup regular expression
+        if let Ok(lookup) = Regex::new(&processor.lookup) {
+
+            // Inform
+            info!("Using post-processor {:#?}", lookup);
+
+            // Remember the regex and the replacement string
+            processors.push((lookup, processor.replace.as_str()));
+        } else {
+
+            // Invalid regex, warn and ignore
+            warn!("Post-processor {:#?} is invalid", processor);
+        }
+    }
+
+    // Track the processed output
+    let mut processed = Vec::new();
+
+    // Take each line in the output
+    for line in output.lines() {
+
+        // Make a mutable copy
+        let mut next: String = line.to_string();
+
+        // Run all available processors through it
+        for processor in &processors {
+
+            // Replace the pattern as appropriate
+            next = processor.0.replace_all(&next, processor.1).to_string();
+        }
+
+        // Replace line with the processed
+        processed.push(next);
+    }
+
+    // Return what we ended with
+    processed.join("\n")
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -12,6 +12,7 @@ use std::collections::{HashMap, HashSet};
 pub struct Report<'a> {
     /// Scoped changes in the report
     pub scopes: Vec<Scope>,
+
     /// All interesting commits
     pub commits: &'a [Commit],
 }
@@ -21,6 +22,7 @@ pub struct Report<'a> {
 pub struct Scope {
     /// The title of the scope
     pub title: String,
+
     /// A list of categorized changes
     pub categories: Vec<Category>,
 }
@@ -30,6 +32,7 @@ pub struct Scope {
 pub struct Category {
     /// The title of the category
     pub title: String,
+
     /// A list of change descriptions
     pub changes: Vec<Text>,
 }
@@ -39,8 +42,10 @@ pub struct Category {
 pub struct Text {
     /// A sequence number to inform ordering
     pub sequence: u32,
+
     /// An opening headline
     pub opening: String,
+
     /// The remaining lines in the description
     pub rest: Vec<String>,
 }
@@ -53,8 +58,10 @@ type RawReport = HashMap<String, HashMap<String, Vec<Text>>>;
 struct State {
     /// The current text
     text: Vec<String>,
+
     /// The current scope
     scope: Option<String>,
+
     /// The current category
     category: Option<String>,
 }
@@ -142,11 +149,10 @@ fn second_pass(config: &Configuration, report: &RawReport) -> Vec<Scope> {
 
                 // Skip it.
                 continue;
-            } else {
-
-                // Remember this scope title as processed
-                processed_scopes.insert(&scope.title);
             }
+
+            // Remember this scope title as processed
+            processed_scopes.insert(&scope.title);
 
             // Go through all configured scopes
             for category in &config.categories {
@@ -156,11 +162,10 @@ fn second_pass(config: &Configuration, report: &RawReport) -> Vec<Scope> {
 
                     // Skip it.
                     continue;
-                } else {
-
-                    // Remember this category title as processed
-                    processed_categories.insert(&category.title);
                 }
+
+                // Remember this category title as processed
+                processed_categories.insert(&category.title);
 
                 // If there are changes of this category
                 if let Some(changes) = categorized.get(&category.title) {
@@ -222,7 +227,7 @@ fn record(raw: &mut RawReport, config: &Configuration, mut state: State, seq: &m
         let rest = state.text;
 
         // Increment the sequence
-        *seq = *seq + 1;
+        *seq += 1;
 
         // Record it in the raw report
         raw.entry(scope.unwrap())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 #[test]
 fn default_configuration_is_valid() {
-    let config = super::config::from(None);
+    let config = super::config::from(&None);
     assert!(config.is_ok());
 }
 
@@ -102,7 +102,7 @@ fn parse_commit() {
 fn prepare_report() {
     use super::*;
     let commits = vec![fake_commit()];
-    let config = config::from(None).unwrap();
+    let config = config::from(&None).unwrap();
     let report = report::generate(&config, &commits);
     println!("{:#?}", &report);
     output::render(&config, &report);
@@ -124,6 +124,6 @@ fn postprocess() {
     let mut config = config::Configuration::default();
     config.post_processors = vec![jira];
 
-    let output = output::postprocess(&config, input);
+    let output = output::postprocess(&config, &input);
     assert_eq!(&output, "Fixed [JIRA-1234](https://jira.company.com/1234)");
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -104,11 +104,26 @@ fn prepare_report() {
     let commits = vec![fake_commit()];
     let config = config::from(None).unwrap();
     let report = report::generate(&config, &commits);
-    println!("{}", serde_json::to_string_pretty(&report).unwrap());
+    println!("{:#?}", &report);
     output::render(&config, &report);
     assert_eq!(report.commits.len(), 1);
     assert_eq!(report.scopes.len(), 2);
     assert_eq!(report.scopes[0].categories[0].title, "Features");
     assert_eq!(report.scopes[0].categories[1].title, "Notes");
     assert_eq!(report.scopes[1].categories[0].title, "Breaking Changes");
+}
+
+#[test]
+fn postprocess() {
+    use super::*;
+    let input = String::from("Fixed JIRA-1234");
+    let jira = config::PostProcessor {
+        lookup: r"JIRA-(?P<t>\d+)".to_string(),
+        replace: r"[JIRA-$t](https://jira.company.com/$t)".to_string(),
+    };
+    let mut config = config::Configuration::default();
+    config.post_processors = vec![jira];
+
+    let output = output::postprocess(&config, input);
+    assert_eq!(&output, "Fixed [JIRA-1234](https://jira.company.com/1234)");
 }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -6,25 +6,14 @@ use report;
 use output;
 use commit;
 use config;
-
-/// The exit code catalog
-mod exit {
-    /// All well
-    pub const OK: i32 = 0;
-
-    /// Not in a git repository
-    pub const NOT_GIT: i32 = 1;
-
-    /// No commits were found in range
-    pub const NO_COMMITS: i32 = 2;
-}
+use exitcode;
 
 /// The main tool entry-point
-pub fn run(config: &config::Configuration, given_range: Option<Vec<String>>) -> i32 {
+pub fn run(config: &config::Configuration, given_range: Option<Vec<String>>) -> exitcode::ExitCode {
 
     // First things first, are we even in a git repository?
     if git::in_git_repository().is_err() {
-        return exit::NOT_GIT;
+        return exitcode::NOINPUT;
     }
 
     // Decide the revision range we'll use for the report
@@ -63,7 +52,7 @@ pub fn run(config: &config::Configuration, given_range: Option<Vec<String>>) -> 
     // We need a list of commits to make progress
     if hashes.is_err() {
         error!("No commits in range. {:?}", hashes);
-        return exit::NO_COMMITS;
+        return exitcode::NOINPUT;
     }
 
     // A list of all commits
@@ -101,5 +90,5 @@ pub fn run(config: &config::Configuration, given_range: Option<Vec<String>>) -> 
     output::render(config, &report);
 
     // Done
-    exit::OK
+    exitcode::OK
 }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -91,6 +91,9 @@ pub fn run(config: &config::Configuration, given_range: Option<Vec<String>>) -> 
         }
     }
 
+    // Order the commits by time
+    commits.sort_by(|a, b| a.time.cmp(&b.time));
+
     // Prepare the report
     let report = report::generate(config, &commits);
 


### PR DESCRIPTION
- feature: The tool now automatically uses a configuration file
  `.changelog.yml` in the current directory. If a file with that
  name doesn't exist in the current directory, it looks up the
  directory tree in the parent directories as long as it reaches
  the root. This simplifies project specific configuration by
  checking in a `.changelog.yml` in the repo root.

- feature: The configuration can now specifiy post-processors
  that look for specific markers like (e.g. `JIRA-12345`) and
  replaces them with suitable replacements. This makes adding
  links like [JIRA-1234](http://jira.company.com/view/JIRA-1234)
  easy. In general, a post-processor is a `(lookup,replacement)`
  tuple where a `lookup` is a regex with named capture groups
  like `JIRA-(?P<ticket>\\d+)`) and
  [replacement](https://doc.rust-lang.org/regex/regex/index.html#example-replacement-with-named-capture-groups)
  is a simple string that refers to the named capture groups like
  `[JIRA-$ticket](http://jira.company.com/view/JIRA-$ticket)`