### PR TITLE
Accept all that `git log` can accept to pick commits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version     = "0.3.1-nightly"
+version     = "0.3.1"
 name        = "git-changelog"
 authors     = ["Aldrin J D'Souza <code@aldrin.co>"]
 description = "A tool to automate project changelog generation."

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ this](src/assets/sample.md).
 When you wish to record a *user visible* change (e.g. new feature, bug fix, breaking change, etc.)
 you write a normal commit message and annotate some lines in it with your chosen keywords. The
 annotated lines are used at report generation time to organize changes into *categories* and
-*scopes*. The organized changes are then rendered as a pretty and accurate change log. Commit
-messages without tags are quietly ignored and you are free to tag as little or as much as you want.
+*scopes*. The organized changes are then rendered as a pretty and accurate change log. 
 
-Here's a quick demo:
+Commit messages without tags are quietly ignored and you are free to tag as little or as much as you
+want. Here's a quick demo:
 
 [![asciicast](https://asciinema.org/a/Jk8A5UEJGkhlalL4gl3HevC7e.png)](https://asciinema.org/a/Jk8A5UEJGkhlalL4gl3HevC7e)
 
@@ -158,12 +158,11 @@ Fixes: [JIRA-1234](https://jira.company.com/view/JIRA-1234)
 ```
 
 [should]:https://chris.beams.io/posts/git-commit/
-[library documentation]: file:///Users/aldrin/Code/git-changelog/target/doc/changelog/struct.ChangeLog.html
+[library documentation]: https://docs.rs/git-changelog/0.3.1/changelog/struct.ChangeLog.html
 [change logs]: http://keepachangelog.com/
 [revision range]: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#_commit_ranges
 [Handlebars]: http://handlebarsjs.com/
 [Homebrew]: https://brew.sh/
 [CHANGELOG.md]: CHANGELOG.md
-[v0.1.1]: https://github.com/aldrin/git-changelog/tree/v0.1.1
 [.changelog.yml]: .changelog.yml
 [releases]:https://github.com/aldrin/git-changelog/releases

--- a/README.md
+++ b/README.md
@@ -4,10 +4,20 @@
 [![GitHub release](https://img.shields.io/github/release/aldrin/git-changelog.svg)](https://github.com/aldrin/git-changelog/releases)
 [![codecov](https://codecov.io/gh/aldrin/git-changelog/branch/master/graph/badge.svg)](https://codecov.io/gh/aldrin/git-changelog)
 
-`git-changelog` is a tool to automate repository [changelog] generation.
-
-A commit [like this](src/assets/sample-commit.message) generates an output [like
+`git-changelog` is a tool to generate [change logs] (a.k.a release notes) that are typically
+distributed at project release milestones. Unlike other tools that do the same, this one does not
+require you to follow any particular git workflow conventions. All it assumes is that you'll pick a
+few keywords (or use the built-in ones) to annotate lines in your commit messages. Concretely, a
+commit [like this](src/assets/sample-commit.message) generates an output [like
 this](src/assets/sample.md).
+
+When you wish to record a *user visible* change (e.g. new feature, bug fix, breaking change, etc.)
+you write a normal commit message and annotate some lines in it with your chosen keywords. The
+annotated lines are used at report generation time to organize changes into *categories* and
+*scopes*. The organized changes are then rendered as a pretty and accurate change log. Commit
+messages without tags are quietly ignored and you are free to tag as little or as much as you want.
+
+Here's a quick demo:
 
 [![asciicast](https://asciinema.org/a/Jk8A5UEJGkhlalL4gl3HevC7e.png)](https://asciinema.org/a/Jk8A5UEJGkhlalL4gl3HevC7e)
 
@@ -81,9 +91,33 @@ You just need to tag the changes you want your users to know about.
 
 ## Generate reports
 
-When `git-changelog` is on the path, `git changelog` works like `git log` and takes *similar*
-arguments. It looks at all commits in the given [commit range] and uses the tags it finds in their
-messages to generate a report. Simple. 🙂
+Once on `PATH`, the tool works like a usual git sub-command (e.g. like `git log`) and takes a
+[revision range] as input. It looks at all commits in the range and uses the keywords it finds in
+their messages to generate the report. Simple. 🙂
+
+```bash
+$ git changelog v0.1.1..v0.2.0
+```
+
+If you don't provide a revision range, `<last-tag>..HEAD` is used. If no tags are defined, just the
+last commit is picked.
+
+```bash
+$ git changelog -d
+INFO: Reading file '/Users/aldrin/Code/git-changelog/.changelog.yml'
+INFO: Using revision range 'v0.2.0..HEAD (15 commits)'
+...
+```
+
+Note that using `-d` gives you some insight into the tool operations. 
+
+For more complex range selections you can use `git log` arguments as shown below:
+
+```bash
+$ git changelog -- --author aldrin --reverse --since "1 month ago"
+```
+
+Note the `--` before you start the `git log` arguments.
 
 ## Customization
 
@@ -96,7 +130,10 @@ the [default configuration file](src/assets/changelog.yml) for a starting exampl
 
 **Templates**: You can specify your own [Handlebars] template if the output doesn't work for
 you. Add a `.changelog.hbs` to your repository root or use the `--template` command line option. See
-the [default template](src/assets/changelog.hbs) for a starting example.
+the [default template](src/assets/changelog.hbs) for a starting example and the [library
+documentation] for details on the input data-structure.
+
+**JSON**: You can skip Markdown completely and ask for a JSON output with the `--json` flag.
 
 **Post Processors**: You can add line post-processors to tweak the output. I use these to simplify
 adding links to bug-tracking systems. For example, the commit message can simply state the ticket
@@ -106,7 +143,7 @@ number:
 Fixes: JIRA-1234
 ```
 
-Then, with a post-processor like the following in the configuration
+Then, with a post-processor like the following in the configuration file:
 
 ```yml
 output:
@@ -114,15 +151,16 @@ output:
     - {lookup: "JIRA-(?P<id>\\d+)", replace: "[JIRA-$id](https://jira.company.com/view/JIRA-$id)"}
 ```
 
-the tool will emit the following:
+the tool replaces it with:
 
 ```
 Fixes: [JIRA-1234](https://jira.company.com/view/JIRA-1234)
 ```
 
 [should]:https://chris.beams.io/posts/git-commit/
-[changelog]: http://keepachangelog.com/
-[commit range]: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#_commit_ranges
+[library documentation]: file:///Users/aldrin/Code/git-changelog/target/doc/changelog/struct.ChangeLog.html
+[change logs]: http://keepachangelog.com/
+[revision range]: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#_commit_ranges
 [Handlebars]: http://handlebarsjs.com/
 [Homebrew]: https://brew.sh/
 [CHANGELOG.md]: CHANGELOG.md

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -28,7 +28,13 @@ pub struct Commit {
 }
 
 /// A list of commit revisions
-pub struct CommitList(Vec<String>);
+pub struct CommitList {
+    /// The log command
+    input: String,
+
+    /// The commits in the log
+    commits: Vec<String>,
+}
 
 /// The commit message
 pub struct CommitMessage<'a>(Vec<&'a str>);
@@ -77,23 +83,35 @@ impl Commit {
     }
 }
 
-impl<T: AsRef<str>> From<T> for CommitList {
-    fn from(input: T) -> Self {
-        let range = input.as_ref();
-        CommitList(match git::commits_in_range(range) {
-            Ok(shas) => shas,
+impl<'a> From<&'a str> for CommitList {
+    /// Convenience constructor from a simple range
+    fn from(range: &str) -> Self {
+        Self::from(vec![range.to_string()])
+    }
+}
+
+impl From<Vec<String>> for CommitList {
+    /// Generate a commit list from the list of strings, interpreting them as `git log` arguments.
+    fn from(git_log_args: Vec<String>) -> Self {
+        // Record the log input
+        let input = git_log_args.join(" ");
+
+        // Get the commits that `git log` would have returned
+        let commits = match git::commits_in_log(&git_log_args) {
+            Ok(commits) => commits,
             Err(why) => {
-                error!("Invalid range {} (Reason: {})", range, why);
+                error!("Invalid log input {} (Reason: {})", input, why);
                 vec![]
             }
-        })
+        };
+        CommitList { commits, input }
     }
 }
 
 impl Iterator for CommitList {
     type Item = Commit;
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.pop().map(Commit::from)
+        self.commits.pop().map(Commit::from)
     }
 }
 
@@ -119,6 +137,12 @@ impl<'a> Iterator for CommitMessage<'a> {
 impl fmt::Display for Commit {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}:{}", self.sha, self.summary)
+    }
+}
+
+impl fmt::Display for CommitList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} ({} commits)", self.input, self.commits.len())
     }
 }
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -271,11 +271,11 @@ mod tests {
     fn commit_fetch() {
         use super::{Commit, CommitList};
         let head = Commit::from("2c5dda2e");
-        let also_head = CommitList::from("2c5dda2e^..2c5dda2e")
-            .into_iter()
-            .next()
-            .unwrap();
+        let list = CommitList::from("2c5dda2e^..2c5dda2e");
+        assert_eq!(list.to_string(), "2c5dda2e^..2c5dda2e (1 commits)");
+        let also_head = list.into_iter().next().unwrap();
         assert_eq!(head.sha, also_head.sha);
+        assert!(head.to_string().starts_with("2c5dda2e"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,23 +2,72 @@
 // Licensed under the MIT License <https://opensource.org/licenses/MIT>
 //! A generator for categorized change logs.
 //!
-//! This crate generates change logs (a.k.a release notes) that are typically distributed at project release
-//! milestones. It looks for keywords in git commit messages and uses them to produce a presentable and categorized
-//! change log.
+//! This crate generates change logs (a.k.a release notes) that are typically distributed at project
+//! release milestones. Unlike other tools that do the same, this one does not require you to follow
+//! any particular git workflow conventions. All it assumes is that you'll pick a few *keywords* (or
+//! use the built-in ones) to annotate lines in your commit messages.
 //!
-//! The associated crate [`git-changelog`] provides an executable wrapper around this crate.
+//! When you wish to record a user visible change (e.g. new feature, bug fix, breaking change, etc.)
+//! you write a normal commit message and annotate some lines in it with your chosen keywords. The
+//! annotated lines are used at report generation time to organize changes into *categories* and
+//! *scopes*. The organized changes are then rendered as a pretty and accurate change log. Commit
+//! messages without tags are quietly ignored and you are free to tag as little or as much as you
+//! want.
 //!
-//! # Use
+//! See [README] for details.
+//!
+//! # Usage
+//!
+//! Install the executable wrapper as follows:
+//!
+//! ```bash
+//! $ cargo install git-changelog
+//! ```
+//!
+//! Once on `PATH`, the tool works like a normal git sub-command (e.g. `git log`) and takes a
+//! [revision range] as input. It looks at all commits in the range and uses the keywords it finds
+//! in their messages to generate the report. Simple. 🙂
+//!
+//! ```bash
+//! $ git changelog v0.1.1..v0.2.0
+//! ```
+//!
+//! If you don't provide a revision range, `<last-tag>..HEAD` is used. If no tags are defined, just
+//! the last commit is picked.
+//!
+//! ```bash
+//! $ git changelog -d
+//! INFO: Reading file '/Users/aldrin/Code/git-changelog/.changelog.yml'
+//! INFO: Using revision range 'v0.2.0..HEAD (15 commits)'
+//! ...
+//! ```
+//!
+//! Note that using `-d` can you give you some insight into the tool operations. For more complex range
+//! selections you can use `git log` arguments as shown below:
+//!
+//! ```bash
+//! $ git changelog -- --author aldrin --reverse --since "1 month ago"
+//! ```
+//!
+//! Note the `--` before you start the `git log` arguments.
+//!
+//! # Library Usage
 //!
 //! The crate functionality is also usable as a library as shown below:
+//!
+//! ```toml
+//! [dependencies]
+//! git-changelog = "0.3"
+//! ```
 //!
 //! ```rust
 //! extern crate changelog;
 //! println!("{}", changelog::ChangeLog::new());
 //! ```
 //!
-//! The configuration used in simple example shown above is picked from the repository configuration file (if one is
-//! found) or from built-in defaults. Advanced usage can programmatically manage these as follows:
+//! The configuration used in simple example shown above is picked from the repository configuration
+//! file (if one is found) or from built-in defaults. Advanced usage can programmatically manage
+//! these as follows:
 //!
 //! ```rust
 //! use changelog::{Configuration, Keyword, ChangeLog};
@@ -31,7 +80,7 @@
 //! config.conventions.categories.push(Keyword::new("break", "Breaking Changes"));
 //!
 //! // Pick the range of commits
-//! let range = String::from("v0.1.1..v0.2.0");
+//! let range = "v0.1.1..v0.2.0";
 //!
 //! // Generate a changelog for the range with the configuration
 //! let changelog = ChangeLog::from_range(range, &config);
@@ -42,8 +91,8 @@
 //! // Render
 //! assert!(changelog::render(&changelog, &config.output).is_ok());
 //! ```
-//!
-//! [`git-changelog`]: ../git_changelog/index.html
+//! [revision range]: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#double_dot
+//! [README]: https://github.com/aldrin/git-changelog/blob/master/README.md
 
 extern crate chrono;
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,64 +1,6 @@
 // Copyright 2017-2018 by Aldrin J D'Souza.
 // Licensed under the MIT License <https://opensource.org/licenses/MIT>
-
-//! This crate implements an executable wrapper around the [`changelog`] crate.
-//!
-//! The tool automates repository changelog generation without enforcing any git workflow conventions. When developers
-//! wish to record a "user visible" change to the repository (e.g. new feature, bug fix, breaking change, etc.) they
-//! can tag lines in their commit message with a few keywords. These tags are then used to organize changes made to
-//! the repository into scopes and categories and these organized changes can then be presented as pretty change-logs
-//! or release notes. Commits messages without tags are quietly ignored and developers are free to tag as little or as
-//! much as they want.
-//!
-//! ## Install
-//!
-//! ```bash
-//! $ cargo install git-changelog
-//! ```
-//!
-//! ## Usage
-//!
-//! When on `PATH`, the tool works like a usual git subcommand (e.g. like `git log`) and takes a [revision range] as
-//! input:
-//!
-//! ```bash
-//! $ git changelog v0.1.1..v0.2.0
-//! ```
-//!
-//! The revision range selects the commits to be included in the report and the tool looks for the configured keywords
-//! in the commit messages for all chosen commits. The keywords used for identifying change category and scopes can
-//! be picked for a given repository or a given run. The report output can also be tweaked by adding a [Handlebars]
-//! template. See [README] for details.
-//!
-//! The usage string shows
-//!
-//! ```bash
-//! $ git changelog -h
-//! git-changelog 0.3.0
-//! Aldrin J D'Souza <code@aldrin.co>
-//! A tool to automate project changelog generation.
-//!
-//! USAGE:
-//! git-changelog [FLAGS] [OPTIONS] [RANGE]...
-//!
-//! FLAGS:
-//! -d, --debug    Enables debug logs
-//! -h, --help     Prints help information
-//! -j, --json     Generates report as JSON
-//!
-//! OPTIONS:
-//! -c, --config <FILE>      Sets a custom project conventions file
-//! -r, --remote <REMOTE>    Sets a remote name form change links
-//! -t, --template <FILE>    Sets a custom Handlebars template file
-//!
-//! ARGS:
-//! <RANGE>...    Picks a revision range
-//! ```
-//!
-//! [revision range]: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#double_dot
-//! [README]: https://github.com/aldrin/git-changelog/README.md
-//! [Handlebars]: http://handlebarsjs.com/
-//! [`changelog`]: ../changelog/index.html
+// The executable wrapper
 
 extern crate changelog;
 #[macro_use]
@@ -105,18 +47,21 @@ fn run(args: Vec<OsString>) -> Result<String> {
 
     // Initialize the tool configuration
     let mut config = Configuration::from_file(cli.value_of("config"))?;
-    debug!("{:#?}", config);
 
     // Pick overrides from the command line
     config.output.json = cli.is_present("json");
-    config.output.remote = cli.value_of("remote").map(str::to_owned);
-    config.output.template = cli.value_of("template").map(str::to_owned);
+    let cmd = cli.value_of("remote").map(str::to_owned);
+    config.output.remote = cmd.or(config.output.remote);
+    let cmd = cli.value_of("template").map(str::to_owned);
+    config.output.template = cmd.or(config.output.template);
+
+    debug!("{:#?}", config);
 
     // Initialize the revision range
-    let range = cli.values_of_lossy("range").unwrap_or_default().join(" ");
+    let range = cli.values_of_lossy("range").unwrap_or_default();
 
     // Generate the change log for the range with the config
-    let changelog = ChangeLog::from_range(range, &config);
+    let changelog = ChangeLog::from_log(range, &config);
     trace!("{:#?}", changelog);
 
     // Render the change log with the given output choices

--- a/src/output.rs
+++ b/src/output.rs
@@ -6,9 +6,7 @@ use std::fmt;
 use regex::Regex;
 use handlebars::{Handlebars, Helper, RenderContext, RenderError};
 use serde_json::to_string_pretty;
-use super::Result;
-use changelog::ChangeLog;
-use input::{OutputPreferences, PostProcessor};
+use super::{ChangeLog, OutputPreferences, PostProcessor, Result};
 
 type RenderResult = ::std::result::Result<(), RenderError>;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -33,7 +33,7 @@ fn library_example() {
         .push(Keyword::new("break", "Breaking Changes"));
 
     // Pick the range of commits
-    let range = String::from("v0.1.1..v0.2.0");
+    let range = "v0.1.1..v0.2.0";
 
     // Generate a changelog for the range with the configuration
     let changelog = ChangeLog::from_range(range, &config);


### PR DESCRIPTION
- feature: The tool now accepts `git log` arguments to choose
  commits to be included in the report. For example:

  ```bash
  # My changes in reverse chronological order
  > git changelog -- --author aldrin --reverse
  ```

  ```bash
  # All changes since yesterday
  > git changelog -- --since yesterday
  ```

  Note that you need a `--` before you begin `git log` arguments.

- feature: Values for the command line arguments `--template` and
  `--remote` can now be specified in configuration file as well.