### PR TITLE
Reduce lib dependency footprint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ readme      = "README.md"
 keywords    = ["git", "changelog", "report", "project", "status"]
 categories  = ["command-line-utilities", "development-tools"]
 
+[features]
+default = ["bin"]
+bin = ["console", "clap", "env_logger"]
+
 [dependencies]
 anyhow       = "1"
 log          = "0.4"
@@ -17,15 +21,16 @@ nom          = "3.2"
 chrono       = "0.4"
 regex        = "1.4"
 serde        = "1.0"
-console      = "0.14"
+console      = { version = "0.14", optional = true }
 handlebars   = "3.5"
-env_logger   = "0.8"
+env_logger   = { version = "0.8", optional = true }
 serde_yaml   = "0.8"
 serde_json   = "1.0"
 serde_derive = "1.0"
-clap         = { version = "2", features = ["yaml"] }
+clap         = { version = "2", features = ["yaml"], optional = true }
 
 [dev-dependencies]
+env_logger   = "0.8"
 difference   = "1.0"
 
 [lib]
@@ -33,6 +38,7 @@ name = "changelog"
 
 [[bin]]
 name = "git-changelog"
+required-features = ["bin"]
 
 [badges]
 maintenance                       = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords    = ["git", "changelog", "report", "project", "status"]
 categories  = ["command-line-utilities", "development-tools"]
 
 [features]
-default = ["bin"]
+default = ["bin", "handlebars"]
 bin = ["console", "clap", "env_logger"]
 
 [dependencies]
@@ -22,7 +22,7 @@ chrono       = "0.4"
 regex        = "1.4"
 serde        = "1.0"
 console      = { version = "0.14", optional = true }
-handlebars   = "3.5"
+handlebars   = { version = "3.5", optional = true }
 env_logger   = { version = "0.8", optional = true }
 serde_yaml   = "0.8"
 serde_json   = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,24 @@
 //! // Render
 //! assert!(changelog::render(&changelog, &config.output).is_ok());
 //! ```
+//!
+//! # Crate features
+//!
+//! There are two features you can disable when depending on the crate as a library,
+//! which will reduce the additional dependencies you incur:
+//!
+//! - `bin`: Required to compile the standalone executable target
+//! - `handlebars`: Required to render Handlebars templates with `changelog::render`
+//!
+//! To control which of these you take, you can use the following alternative in your Cargo.toml:
+//!
+//! ```toml
+//! [dependencies.git-changelog]
+//! default-features = false
+//! # features = ["handlebars"] # Optionally cherry-pick the `handlebars` support
+//! version = "0.3"
+//! ```
+//!
 //! [revision range]: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#double_dot
 //! [README]: https://github.com/aldrin/git-changelog/blob/master/README.md
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@
 extern crate chrono;
 #[macro_use]
 extern crate anyhow;
+#[cfg(feature = "handlebars")]
 extern crate handlebars;
 #[macro_use]
 extern crate log;
@@ -113,6 +114,8 @@ mod commit;
 mod git;
 mod input;
 mod output;
+#[cfg(feature = "handlebars")]
+mod template_hbs;
 
 pub use changelog::Category;
 pub use changelog::ChangeLog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "handlebars")]
     fn run() {
         assert!(super::run(to_args("git-changelog v0.1.1..v0.2.1")).is_ok());
         assert!(super::run(to_args("git-changelog -d v0.1.1..v0.2.1")).is_ok());
@@ -138,6 +139,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "handlebars")]
     fn show() {
         assert_eq!(
             super::show(super::run(to_args("git-changelog v0.1.1..v0.2.1"))),

--- a/src/template_hbs.rs
+++ b/src/template_hbs.rs
@@ -1,0 +1,37 @@
+// Licensed under the MIT License <https://opensource.org/licenses/MIT>
+use super::{ChangeLog, Result};
+use handlebars::{Context, Handlebars, Helper, Output, RenderContext, RenderError};
+
+type RenderResult = ::std::result::Result<(), RenderError>;
+
+pub fn render_template(template: &str, clog: &ChangeLog) -> Result<String> {
+    let mut hbs = Handlebars::new();
+    hbs.register_helper("tidy-change", Box::new(tidy));
+    hbs.render_template(template, clog)
+        .map_err(|e| format_err!("Handlebar render failed: {}", e))
+}
+
+/// A handlebar helper to tidy up markdown lists used to render changes.
+fn tidy(
+    h: &Helper,
+    _: &Handlebars,
+    _: &Context,
+    _: &mut RenderContext,
+    out: &mut dyn Output,
+) -> RenderResult {
+    if let Some(indent) = h.param(0).and_then(|v| v.value().as_str()) {
+        if let Some(text) = h.param(1).and_then(|v| v.value().as_str()) {
+            let mut lines = text.lines();
+            if let Some(first) = lines.next() {
+                out.write(first.trim())?;
+                out.write("\n")?;
+            }
+            for line in lines {
+                out.write(indent)?;
+                out.write(line)?;
+                out.write("\n")?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,6 +8,7 @@ use changelog::*;
 use regex::Regex;
 
 #[test]
+#[cfg(feature = "handlebars")]
 fn readme_example() {
     let config = builtin_config();
     let commits = vec![readme_commit()];


### PR DESCRIPTION
Two changes to allow taking git-changelog as a library dependency and incur fewer additional dependencies.