### PR TITLE
Switch to `anyhow` instead of `failure`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ keywords    = ["git", "changelog", "report", "project", "status"]
 categories  = ["command-line-utilities", "development-tools"]
 
 [dependencies]
+anyhow       = "1"
 log          = "0.4"
 nom          = "3.2"
 chrono       = "0.4"
 regex        = "1.4"
 serde        = "1.0"
-failure      = "0.1"
 console      = "0.14"
 handlebars   = "3.5"
 env_logger   = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 
 extern crate chrono;
 #[macro_use]
-extern crate failure;
+extern crate anyhow;
 extern crate handlebars;
 #[macro_use]
 extern crate log;
@@ -130,4 +130,4 @@ pub use input::CONFIG_FILE;
 pub use input::TEMPLATE_FILE;
 pub use output::render;
 
-pub type Result<T> = std::result::Result<T, failure::Error>;
+pub type Result<T> = std::result::Result<T, anyhow::Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,9 @@
 extern crate changelog;
 #[macro_use]
 extern crate clap;
+extern crate anyhow;
 extern crate console;
 extern crate env_logger;
-extern crate failure;
 #[macro_use]
 extern crate log;
 
@@ -122,7 +122,7 @@ fn initialize_logging(verbosity: u64) {
 
 #[cfg(test)]
 mod tests {
-    use failure::err_msg;
+    use anyhow::anyhow;
     use std::ffi::OsString;
 
     fn to_args(cmd: &str) -> Vec<OsString> {
@@ -144,6 +144,6 @@ mod tests {
             0
         );
         assert_eq!(super::show(Ok(String::from("foo"))), 0);
-        assert_eq!(super::show(Err(err_msg("foo"))), 1);
+        assert_eq!(super::show(Err(anyhow!("foo"))), 1);
     }
 }


### PR DESCRIPTION
The `failure` crate is deprecated, and `anyhow` seems to be the de facto error handling crate these days, so switch over. (Plus, `anyhow::Error` implements the `std::errror::Error` trait, so it's easier to interoperate with other error handling.)